### PR TITLE
feat: :globe_with_meridians: Add bilingual (zh/en) support with local…

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -1,0 +1,53 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+const LOCALE_COOKIE = 'NEXT_LOCALE';
+
+type Locale = 'zh' | 'en';
+
+function pickFromAcceptLanguage(accept: string | null): Locale {
+  if (!accept) return 'zh';
+  const langs = accept
+    .toLowerCase()
+    .split(',')
+    .map((part) => part.split(';')[0].trim());
+  for (const lang of langs) {
+    if (lang.startsWith('en')) return 'en';
+    if (lang.startsWith('zh')) return 'zh';
+  }
+  return 'zh';
+}
+
+function readCookieLocale(req: NextRequest): Locale | null {
+  const value = req.cookies.get(LOCALE_COOKIE)?.value;
+  if (value === 'zh' || value === 'en') return value;
+  return null;
+}
+
+export function middleware(req: NextRequest) {
+  const { pathname } = req.nextUrl;
+
+  const requestHeaders = new Headers(req.headers);
+  requestHeaders.set('x-pathname', pathname);
+
+  const isEnPath = pathname === '/en' || pathname.startsWith('/en/');
+  if (isEnPath) {
+    return NextResponse.next({ request: { headers: requestHeaders } });
+  }
+
+  const cookieLocale = readCookieLocale(req);
+  const desired: Locale =
+    cookieLocale ?? pickFromAcceptLanguage(req.headers.get('accept-language'));
+
+  if (desired === 'en') {
+    const target = pathname === '/' ? '/en' : `/en${pathname}`;
+    return NextResponse.redirect(new URL(target, req.url));
+  }
+
+  return NextResponse.next({ request: { headers: requestHeaders } });
+}
+
+export const config = {
+  matcher: [
+    '/((?!api|_next/static|_next/image|favicon.ico|meta/|assets/|.*\\..*).*)',
+  ],
+};

--- a/src/app/_components/comment-form.tsx
+++ b/src/app/_components/comment-form.tsx
@@ -5,12 +5,19 @@ import { useUser } from '@auth0/nextjs-auth0/client';
 import clsx from 'clsx';
 
 import { createComment } from '@/lib/actions';
+import { Locale, getMessages } from '@/lib/i18n';
 import Avatar from './avatar';
 import LogoutButton from './logout-button';
 import LoginButton from './login-button';
 import Spinner from './spinner';
 
-export default function CommentForm({ slug }: { slug: string }) {
+type Props = {
+  slug: string;
+  locale: Locale;
+};
+
+export default function CommentForm({ slug, locale }: Props) {
+  const t = getMessages(locale);
   const { user, error, isLoading } = useUser();
   const [content, setContent] = useState('');
   const [pending, setPending] = useState(false);
@@ -34,7 +41,7 @@ export default function CommentForm({ slug }: { slug: string }) {
   }
 
   if (error || !user) {
-    return <LoginButton />;
+    return <LoginButton locale={locale} />;
   }
 
   return (
@@ -44,11 +51,11 @@ export default function CommentForm({ slug }: { slug: string }) {
         className="mt-4 block w-full resize-y rounded-button border border-outline bg-canvas-surface p-3 text-[15px] leading-relaxed text-ink placeholder:text-ink-subtle focus:border-brand focus:outline-none focus:ring-2 focus:ring-brand/20 dark:border-carbon-border dark:bg-carbon-surface dark:text-carbon-text dark:placeholder:text-carbon-muted"
         rows={4}
         value={content}
-        placeholder="Add your comment..."
+        placeholder={t.comments.placeholder}
         onChange={(e) => setContent(e.target.value)}
       />
       <div className="mt-4 flex items-center justify-between">
-        <LogoutButton />
+        <LogoutButton locale={locale} />
         <button
           type="button"
           className={clsx(
@@ -58,7 +65,7 @@ export default function CommentForm({ slug }: { slug: string }) {
           onClick={createCommentWithSlug}
         >
           {pending && <Spinner color="white" />}
-          <span className={clsx({ 'ml-2': pending })}>Submit</span>
+          <span className={clsx({ 'ml-2': pending })}>{t.comments.submit}</span>
         </button>
       </div>
     </div>

--- a/src/app/_components/comment-item.tsx
+++ b/src/app/_components/comment-item.tsx
@@ -5,12 +5,19 @@ import { useUser } from '@auth0/nextjs-auth0/client';
 
 import { Comment } from '@/interfaces/comment';
 import { deleteComment } from '@/lib/actions';
+import { Locale, getMessages } from '@/lib/i18n';
 import Avatar from './avatar';
 import Spinner from './spinner';
 import DateFormatter from './date-formatter';
 
-export default function CommentItem({ comment }: { comment: Comment }) {
+type Props = {
+  comment: Comment;
+  locale: Locale;
+};
+
+export default function CommentItem({ comment, locale }: Props) {
   const { id, slug, content, author, createdAt } = comment;
+  const t = getMessages(locale);
   const { user } = useUser();
   const deletable = user?.sub === author.sub;
   const [pending, setPending] = useState(false);
@@ -43,7 +50,7 @@ export default function CommentItem({ comment }: { comment: Comment }) {
                 className="font-mono text-xs uppercase tracking-wider text-ink-muted transition-colors hover:text-brand"
                 onClick={deleteCommentById}
               >
-                Delete
+                {t.comments.delete}
               </button>
             )}
           </div>

--- a/src/app/_components/comments.tsx
+++ b/src/app/_components/comments.tsx
@@ -1,37 +1,42 @@
 import CommentForm from './comment-form';
 import CommentItem from './comment-item';
 import { getCommentsBySlug } from '@/lib/data';
+import { Locale, getMessages } from '@/lib/i18n';
 
-export default async function Comments({ slug }: { slug: string }) {
+type Props = {
+  slug: string;
+  locale: Locale;
+};
+
+export default async function Comments({ slug, locale }: Props) {
   const comments = await getCommentsBySlug(slug);
+  const t = getMessages(locale);
 
   return (
     <section className="mt-12">
       <div className="mb-8 flex items-end justify-between">
         <div>
-          <span className="label-mono">— Comments</span>
+          <span className="label-mono">{t.comments.label}</span>
           <h2 className="mt-3 text-h2 font-semibold tracking-tighter text-ink dark:text-carbon-text">
-            Discussion
+            {t.comments.title}
           </h2>
         </div>
-        <span className="label-mono">
-          {comments.length} {comments.length === 1 ? 'reply' : 'replies'}
-        </span>
+        <span className="label-mono">{t.comments.count(comments.length)}</span>
       </div>
       {comments.length > 0 ? (
         <ul className="mb-10 divide-y divide-outline-subtle border-y border-outline-subtle dark:divide-carbon-border dark:border-carbon-border">
           {comments.map((comment) => (
             <li key={comment.id}>
-              <CommentItem comment={comment} />
+              <CommentItem comment={comment} locale={locale} />
             </li>
           ))}
         </ul>
       ) : (
         <p className="mb-10 border-y border-outline-subtle py-8 text-sm text-ink-muted dark:border-carbon-border dark:text-carbon-muted">
-          No comments yet. Be the first to leave a thought.
+          {t.comments.empty}
         </p>
       )}
-      <CommentForm slug={slug} />
+      <CommentForm slug={slug} locale={locale} />
     </section>
   );
 }

--- a/src/app/_components/footer.tsx
+++ b/src/app/_components/footer.tsx
@@ -1,7 +1,13 @@
 import Container from '@/app/_components/container';
 import { AUTHOR_NAME, GITHUB_URL } from '@/lib/constants';
+import { Locale, getMessages } from '@/lib/i18n';
 
-export function Footer() {
+type Props = {
+  locale?: Locale;
+};
+
+export function Footer({ locale = 'zh' }: Props) {
+  const t = getMessages(locale);
   return (
     <footer className="border-t border-outline-subtle py-12 dark:border-carbon-border">
       <Container size="wide">
@@ -22,7 +28,7 @@ export function Footer() {
               GitHub
             </a>
             <span className="font-mono text-xs text-ink-subtle dark:text-carbon-muted">
-              Built with Next.js
+              {t.footer.builtWith}
             </span>
           </div>
         </div>

--- a/src/app/_components/header.tsx
+++ b/src/app/_components/header.tsx
@@ -1,14 +1,20 @@
 import Link from 'next/link';
 
 import { SITE_NAME } from '@/lib/constants';
+import { Locale, homePathFor } from '@/lib/i18n';
 import ThemeSwitcher from './theme-switcher';
 import GithubIcon from './github-icon';
+import LocaleSwitcher from './locale-switcher';
 
-const Header = () => {
+type Props = {
+  locale?: Locale;
+};
+
+const Header = ({ locale = 'zh' }: Props) => {
   return (
     <header className="flex items-center justify-between border-b border-outline-subtle py-6 dark:border-carbon-border">
       <Link
-        href="/"
+        href={homePathFor(locale)}
         className="group flex items-center gap-3 text-sm font-medium tracking-tight text-ink transition-colors hover:text-brand dark:text-carbon-text"
       >
         <span className="inline-block h-1.5 w-1.5 rounded-full bg-brand" />
@@ -16,7 +22,8 @@ const Header = () => {
       </Link>
       <div className="flex items-center gap-1">
         <GithubIcon />
-        <ThemeSwitcher />
+        <LocaleSwitcher />
+        <ThemeSwitcher locale={locale} />
       </div>
     </header>
   );

--- a/src/app/_components/home-view.tsx
+++ b/src/app/_components/home-view.tsx
@@ -1,0 +1,22 @@
+import Container from '@/app/_components/container';
+import { Intro } from '@/app/_components/intro';
+import { Posts } from '@/app/_components/posts';
+import { getAllPosts } from '@/lib/data';
+import { Locale } from '@/lib/i18n';
+
+type Props = {
+  locale: Locale;
+};
+
+export function HomeView({ locale }: Props) {
+  const allPosts = getAllPosts(locale);
+
+  return (
+    <main>
+      <Container size="wide">
+        <Intro locale={locale} />
+        <Posts posts={allPosts} locale={locale} />
+      </Container>
+    </main>
+  );
+}

--- a/src/app/_components/intro.tsx
+++ b/src/app/_components/intro.tsx
@@ -1,21 +1,28 @@
-import { SITE_NAME, SITE_DESCRIPTION } from '@/lib/constants';
+import { SITE_NAME } from '@/lib/constants';
+import { Locale, getMessages } from '@/lib/i18n';
 import ThemeSwitcher from './theme-switcher';
 import GithubIcon from './github-icon';
+import LocaleSwitcher from './locale-switcher';
 import { HeroBackdrop } from './hero-backdrop';
 
-export function Intro() {
+type Props = {
+  locale: Locale;
+};
+
+export function Intro({ locale }: Props) {
+  const t = getMessages(locale);
   return (
     <section className="relative isolate overflow-hidden border-b border-outline-subtle pb-16 pt-24 dark:border-carbon-border md:pb-24 md:pt-32">
       <HeroBackdrop />
       <div className="flex items-start justify-between">
         <div className="max-w-2xl">
           <div className="anim-fade-up flex items-center gap-3">
-            <span className="label-mono">— Personal Blog</span>
+            <span className="label-mono">{t.intro.label}</span>
             <span
               className="cli-cursor inline-flex items-center rounded-md border border-outline-subtle bg-canvas-surface/60 px-2 py-0.5 font-mono text-[11px] text-ink-muted backdrop-blur-sm dark:border-carbon-border dark:bg-carbon-surface/60 dark:text-carbon-muted"
               aria-hidden="true"
             >
-              ~/blog $ ready
+              {t.intro.cliBadge}
             </span>
           </div>
           <h1
@@ -28,7 +35,7 @@ export function Intro() {
             className="anim-fade-up mt-6 max-w-xl text-base leading-relaxed text-ink-muted md:text-lg"
             style={{ animationDelay: '160ms' }}
           >
-            {SITE_DESCRIPTION}
+            {t.siteDescription}
           </p>
         </div>
         <div
@@ -36,7 +43,8 @@ export function Intro() {
           style={{ animationDelay: '200ms' }}
         >
           <GithubIcon />
-          <ThemeSwitcher />
+          <LocaleSwitcher />
+          <ThemeSwitcher locale={locale} />
         </div>
       </div>
       <div
@@ -44,7 +52,8 @@ export function Intro() {
         style={{ animationDelay: '200ms' }}
       >
         <GithubIcon />
-        <ThemeSwitcher />
+        <LocaleSwitcher />
+        <ThemeSwitcher locale={locale} />
       </div>
     </section>
   );

--- a/src/app/_components/legacy-blog-hint.tsx
+++ b/src/app/_components/legacy-blog-hint.tsx
@@ -1,21 +1,29 @@
 'use client';
 
 import { usePathname } from 'next/navigation';
+import { Locale, canonicalize, getMessages } from '@/lib/i18n';
 
-export default function LegacyBlogHint() {
+type Props = {
+  locale?: Locale;
+};
+
+export default function LegacyBlogHint({ locale }: Props) {
   const pathname = usePathname();
-  const isLegacyBlog = /\d{4}\/\d{2}\//.test(pathname);
+  const { locale: detected, canonical } = canonicalize(pathname || '/');
+  const effective: Locale = locale ?? detected;
+  const isLegacyBlog = /\d{4}\/\d{2}\//.test(canonical);
 
   if (!isLegacyBlog) {
     return null;
   }
 
-  const legacyBlogUrl = `https://southerncross.github.io/blog${pathname}`;
+  const legacyBlogUrl = `https://southerncross.github.io/blog${canonical}`;
+  const t = getMessages(effective);
 
   return (
     <div className="card-surface mt-6 max-w-xl px-5 py-4 text-left text-sm text-ink-muted dark:text-carbon-muted">
       <p>
-        或许你是想访问旧的博客文章？可以看这里：
+        {t.notFound.legacyHint}
         <br />
         <a
           className="break-all font-mono text-xs text-brand underline-offset-4 hover:underline"

--- a/src/app/_components/locale-switcher.tsx
+++ b/src/app/_components/locale-switcher.tsx
@@ -1,0 +1,44 @@
+'use client';
+
+import { usePathname, useRouter } from 'next/navigation';
+import clsx from 'clsx';
+import {
+  Locale,
+  LOCALE_COOKIE,
+  canonicalize,
+  getMessages,
+  localePath,
+} from '@/lib/i18n';
+
+export default function LocaleSwitcher({ className }: { className?: string }) {
+  const pathname = usePathname();
+  const router = useRouter();
+  const { locale: current, canonical } = canonicalize(pathname || '/');
+
+  const target: Locale = current === 'zh' ? 'en' : 'zh';
+  const targetPath = localePath(target, canonical);
+  const ariaLabel = getMessages(current).toggle.locale;
+
+  const onClick = () => {
+    document.cookie = `${LOCALE_COOKIE}=${target}; path=/; max-age=${60 * 60 * 24 * 365}; samesite=lax`;
+    router.push(targetPath);
+  };
+
+  return (
+    <button
+      type="button"
+      aria-label={ariaLabel}
+      onClick={onClick}
+      className={clsx(
+        'inline-flex h-9 items-center justify-center gap-1 rounded-button border border-transparent px-2 font-mono text-xs uppercase tracking-wider text-ink-muted transition-colors hover:border-outline hover:text-ink dark:text-carbon-muted dark:hover:border-carbon-border dark:hover:text-carbon-text',
+        className,
+      )}
+    >
+      <span className={clsx(current === 'zh' && 'text-brand')}>中</span>
+      <span aria-hidden="true" className="text-ink-subtle">
+        /
+      </span>
+      <span className={clsx(current === 'en' && 'text-brand')}>EN</span>
+    </button>
+  );
+}

--- a/src/app/_components/login-button.tsx
+++ b/src/app/_components/login-button.tsx
@@ -1,25 +1,31 @@
 'use client';
 
 import { usePathname } from 'next/navigation';
+import { Locale, getMessages } from '@/lib/i18n';
 
-export default function LoginButton() {
+type Props = {
+  locale: Locale;
+};
+
+export default function LoginButton({ locale }: Props) {
   const pathname = usePathname();
+  const t = getMessages(locale);
 
   return (
     <div className="card-surface flex flex-col items-center gap-3 px-6 py-8 text-center md:flex-row md:justify-between md:text-left">
       <div>
         <p className="text-sm font-medium text-ink dark:text-carbon-text">
-          Join the discussion
+          {t.comments.loginCardTitle}
         </p>
         <p className="mt-1 text-sm text-ink-muted dark:text-carbon-muted">
-          Sign in to leave a comment.
+          {t.comments.loginCardHint}
         </p>
       </div>
       <a
         className="btn-primary"
         href={`/api/auth/login?returnTo=${encodeURIComponent(pathname)}`}
       >
-        Log in
+        {t.comments.loginButton}
       </a>
     </div>
   );

--- a/src/app/_components/logout-button.tsx
+++ b/src/app/_components/logout-button.tsx
@@ -1,12 +1,18 @@
 'use client';
 
-export default function LogoutButton() {
+import { Locale, getMessages } from '@/lib/i18n';
+
+type Props = {
+  locale: Locale;
+};
+
+export default function LogoutButton({ locale }: Props) {
   return (
     <a
       className="font-mono text-xs uppercase tracking-wider text-ink-muted transition-colors hover:text-brand dark:text-carbon-muted"
       href="/api/auth/logout"
     >
-      Log out
+      {getMessages(locale).comments.logout}
     </a>
   );
 }

--- a/src/app/_components/post-fallback-callout.tsx
+++ b/src/app/_components/post-fallback-callout.tsx
@@ -1,0 +1,25 @@
+import Link from 'next/link';
+import { Locale, getMessages, postPathFor } from '@/lib/i18n';
+
+type Props = {
+  slug: string;
+  requestedLocale: Locale;
+};
+
+export function PostFallbackCallout({ slug, requestedLocale }: Props) {
+  const t = getMessages(requestedLocale);
+  return (
+    <div
+      role="note"
+      className="mb-8 flex flex-col gap-2 rounded-card border border-outline-subtle bg-canvas-surface/60 px-4 py-3 text-sm text-ink-muted backdrop-blur-sm dark:border-carbon-border dark:bg-carbon-surface/60 dark:text-carbon-muted md:flex-row md:items-center md:justify-between"
+    >
+      <span>{t.post.fallbackCallout}</span>
+      <Link
+        href={postPathFor('zh', slug)}
+        className="font-mono text-xs uppercase tracking-wider text-brand underline-offset-4 hover:underline"
+      >
+        {t.post.fallbackCalloutLink}
+      </Link>
+    </div>
+  );
+}

--- a/src/app/_components/post-header.tsx
+++ b/src/app/_components/post-header.tsx
@@ -1,26 +1,48 @@
 import Avatar from './avatar';
 import { PostTitle } from '@/app/_components/post-title';
 import { AUTHOR_NAME, AUTHOR_AVATAR } from '@/lib/constants';
+import { Locale, getMessages } from '@/lib/i18n';
 import DateFormatter from './date-formatter';
 import { PostHeaderBackdrop } from './post-header-backdrop';
+import { PostFallbackCallout } from './post-fallback-callout';
 
 type Props = {
   title: string;
   date: string;
   slug: string;
+  locale: Locale;
+  requestedLocale: Locale;
+  isFallback: boolean;
 };
 
-export function PostHeader({ title, date, slug }: Props) {
+export function PostHeader({
+  title,
+  date,
+  slug,
+  locale,
+  requestedLocale,
+  isFallback,
+}: Props) {
+  const t = getMessages(locale);
+  const showFallback = isFallback && requestedLocale !== 'zh';
   return (
     <header className="not-prose relative isolate mb-16 overflow-hidden border-b border-outline-subtle pb-10 pt-12 dark:border-carbon-border md:pt-16">
       <PostHeaderBackdrop />
-      <div className="anim-fade-up mb-8 flex items-center gap-4">
-        <span className="label-mono shrink-0">— Article</span>
+      {showFallback && (
+        <div className="anim-fade-up">
+          <PostFallbackCallout slug={slug} requestedLocale={requestedLocale} />
+        </div>
+      )}
+      <div
+        className="anim-fade-up mb-8 flex items-center gap-4"
+        style={{ animationDelay: showFallback ? '40ms' : undefined }}
+      >
+        <span className="label-mono shrink-0">{t.post.label}</span>
         <span
           className="cli-cursor inline-flex shrink-0 items-center rounded-md border border-outline-subtle bg-canvas-surface/60 px-2 py-0.5 font-mono text-[11px] text-ink-muted backdrop-blur-sm dark:border-carbon-border dark:bg-carbon-surface/60 dark:text-carbon-muted"
           aria-hidden="true"
         >
-          cat ./posts/{slug}.md
+          {t.post.cliBadge(slug)}
         </span>
         <span className="h-px flex-1 bg-outline-subtle dark:bg-carbon-border" />
         <DateFormatter

--- a/src/app/_components/post-preview.tsx
+++ b/src/app/_components/post-preview.tsx
@@ -1,5 +1,6 @@
 import Link from 'next/link';
 import { CSSProperties } from 'react';
+import { Locale, getMessages, postPathFor } from '@/lib/i18n';
 import DateFormatter from './date-formatter';
 
 type Props = {
@@ -7,6 +8,8 @@ type Props = {
   title: string;
   date: string;
   slug: string;
+  locale: Locale;
+  isFallback?: boolean;
   className?: string;
   style?: CSSProperties;
 };
@@ -16,21 +19,32 @@ export function PostPreview({
   title,
   date,
   slug,
+  locale,
+  isFallback = false,
   className,
   style,
 }: Props) {
+  const t = getMessages(locale);
+  const showFallbackTag = isFallback && locale !== 'zh';
   return (
     <li className={`group ${className ?? ''}`} style={style}>
       <Link
-        href={`/posts/${slug}`}
+        href={postPathFor(locale, slug)}
         className="grid grid-cols-[auto_1fr_auto] items-baseline gap-6 py-6 transition-colors md:py-7"
       >
         <span className="font-mono text-xs tabular-nums text-ink-subtle dark:text-carbon-muted">
           {String(index).padStart(2, '0')}
         </span>
-        <h3 className="text-lg font-medium leading-snug text-ink transition-colors group-hover:text-brand dark:text-carbon-text md:text-xl">
-          {title}
-        </h3>
+        <div className="flex flex-wrap items-baseline gap-x-3 gap-y-1">
+          <h3 className="text-lg font-medium leading-snug text-ink transition-colors group-hover:text-brand dark:text-carbon-text md:text-xl">
+            {title}
+          </h3>
+          {showFallbackTag && (
+            <span className="rounded border border-outline-subtle px-1.5 py-0.5 font-mono text-[10px] uppercase tracking-widest text-ink-subtle dark:border-carbon-border dark:text-carbon-muted">
+              {t.posts.fallbackTag}
+            </span>
+          )}
+        </div>
         <DateFormatter
           date={date}
           format="yyyy.MM.dd"

--- a/src/app/_components/post-view.tsx
+++ b/src/app/_components/post-view.tsx
@@ -1,0 +1,58 @@
+import { Suspense } from 'react';
+import { getPostBySlug } from '@/lib/data';
+import markdownToHtml from '@/lib/markdownToHtml';
+import { Locale } from '@/lib/i18n';
+import Container from '@/app/_components/container';
+import Header from '@/app/_components/header';
+import { PostBody } from '@/app/_components/post-body';
+import { PostHeader } from '@/app/_components/post-header';
+import Comments from '@/app/_components/comments';
+import Reactions from '@/app/_components/reactions';
+import ReadingProgress from '@/app/_components/reading-progress';
+
+type Props = {
+  slug: string;
+  locale: Locale;
+};
+
+export async function PostView({ slug, locale }: Props) {
+  const post = getPostBySlug(slug, locale);
+  const content = await markdownToHtml(post.content || '');
+
+  return (
+    <main>
+      <div className="sticky top-0 z-40 bg-canvas dark:bg-carbon">
+        <Container size="wide">
+          <Header locale={locale} />
+        </Container>
+        <ReadingProgress />
+      </div>
+      <Container size="narrow" className="pb-24">
+        <article className="prose prose-neutral max-w-none dark:prose-invert md:prose-lg">
+          <PostHeader
+            title={post.title}
+            date={post.date}
+            slug={post.slug}
+            locale={post.locale}
+            requestedLocale={post.requestedLocale}
+            isFallback={post.isFallback}
+          />
+          <div className="anim-fade-up" style={{ animationDelay: '240ms' }}>
+            <PostBody content={content} />
+          </div>
+        </article>
+        <div
+          className="anim-fade-up mt-16 border-t border-outline-subtle pt-10 dark:border-carbon-border"
+          style={{ animationDelay: '320ms' }}
+        >
+          <Suspense>
+            <Reactions slug={post.slug} locale={locale} />
+          </Suspense>
+          <Suspense>
+            <Comments slug={post.slug} locale={locale} />
+          </Suspense>
+        </div>
+      </Container>
+    </main>
+  );
+}

--- a/src/app/_components/posts.tsx
+++ b/src/app/_components/posts.tsx
@@ -1,21 +1,24 @@
 import { Post } from '@/interfaces/post';
+import { Locale, getMessages } from '@/lib/i18n';
 import { PostPreview } from './post-preview';
 
 type Props = {
   posts: Post[];
+  locale: Locale;
 };
 
-export function Posts({ posts }: Props) {
+export function Posts({ posts, locale }: Props) {
+  const t = getMessages(locale);
   return (
     <section className="py-16 md:py-24">
       <div className="mb-10 flex items-end justify-between">
         <div>
-          <span className="label-mono">— Index</span>
+          <span className="label-mono">{t.posts.label}</span>
           <h2 className="mt-4 text-h2 font-semibold tracking-tighter text-ink dark:text-carbon-text">
-            All Posts
+            {t.posts.title}
           </h2>
         </div>
-        <span className="label-mono">{posts.length} entries</span>
+        <span className="label-mono">{t.posts.count(posts.length)}</span>
       </div>
       <ol className="divide-y divide-outline-subtle border-y border-outline-subtle dark:divide-carbon-border dark:border-carbon-border">
         {posts.map((post, idx) => (
@@ -25,6 +28,8 @@ export function Posts({ posts }: Props) {
             title={post.title}
             date={post.date}
             slug={post.slug}
+            locale={locale}
+            isFallback={post.isFallback}
             className="anim-fade-up"
             style={{ animationDelay: `${Math.min(idx, 8) * 60}ms` }}
           />

--- a/src/app/_components/reaction-form.tsx
+++ b/src/app/_components/reaction-form.tsx
@@ -7,11 +7,18 @@ import { useTheme } from 'next-themes';
 
 import { addReaction } from '@/lib/actions';
 import { THEME } from '@/lib/constants';
+import { Locale, getMessages } from '@/lib/i18n';
 
 const EmojiPicker = dynamic(() => import('emoji-picker-react'), { ssr: false });
 
-export default function ReactionForm({ slug }: { slug: string }) {
+type Props = {
+  slug: string;
+  locale: Locale;
+};
+
+export default function ReactionForm({ slug, locale }: Props) {
   const { resolvedTheme } = useTheme();
+  const t = getMessages(locale);
   const onEmojiClick = async (reaction: EmojiClickData) => {
     await addReaction(reaction.emoji, slug);
   };
@@ -21,7 +28,7 @@ export default function ReactionForm({ slug }: { slug: string }) {
       <PopoverTrigger>
         <button
           type="button"
-          aria-label="Add reaction"
+          aria-label={t.reactions.add}
           className="inline-flex h-9 w-9 items-center justify-center rounded-button border border-dashed border-outline-subtle text-ink-muted transition-colors hover:border-brand hover:text-brand dark:border-carbon-border dark:text-carbon-muted"
         >
           <svg

--- a/src/app/_components/reactions.tsx
+++ b/src/app/_components/reactions.tsx
@@ -1,13 +1,20 @@
 import ReactionForm from './reaction-form';
 import { getReactionsBySlug } from '@/lib/actions';
 import ReactionItem from './reaction-item';
+import { Locale, getMessages } from '@/lib/i18n';
 
-export default async function Reactions({ slug }: { slug: string }) {
+type Props = {
+  slug: string;
+  locale: Locale;
+};
+
+export default async function Reactions({ slug, locale }: Props) {
   const reactions = await getReactionsBySlug(slug);
+  const t = getMessages(locale);
 
   return (
     <section className="pb-12">
-      <span className="label-mono">— Reactions</span>
+      <span className="label-mono">{t.reactions.label}</span>
       <ul className="mt-4 flex flex-wrap items-center gap-2">
         {reactions.map((reaction) => {
           return (
@@ -17,7 +24,7 @@ export default async function Reactions({ slug }: { slug: string }) {
           );
         })}
         <li>
-          <ReactionForm slug={slug} />
+          <ReactionForm slug={slug} locale={locale} />
         </li>
       </ul>
     </section>

--- a/src/app/_components/theme-switcher.tsx
+++ b/src/app/_components/theme-switcher.tsx
@@ -5,8 +5,14 @@ import { useEffect, useState } from 'react';
 import clsx from 'clsx';
 
 import { THEME } from '@/lib/constants';
+import { Locale, getMessages } from '@/lib/i18n';
 
-export default function ThemeSwitcher({ className }: { className?: string }) {
+type Props = {
+  className?: string;
+  locale?: Locale;
+};
+
+export default function ThemeSwitcher({ className, locale = 'zh' }: Props) {
   const [mounted, setMounted] = useState(false);
   const { resolvedTheme, setTheme } = useTheme();
 
@@ -19,7 +25,7 @@ export default function ThemeSwitcher({ className }: { className?: string }) {
   return (
     <button
       type="button"
-      aria-label="Toggle theme"
+      aria-label={getMessages(locale).toggle.theme}
       onClick={() => setTheme(isDark ? THEME.LIGHT : THEME.DARK)}
       className={clsx(
         'inline-flex h-9 w-9 items-center justify-center rounded-button border border-transparent text-ink-muted transition-colors hover:border-outline hover:text-ink dark:text-carbon-muted dark:hover:border-carbon-border dark:hover:text-carbon-text',

--- a/src/app/en/page.tsx
+++ b/src/app/en/page.tsx
@@ -1,0 +1,5 @@
+import { HomeView } from '@/app/_components/home-view';
+
+export default function IndexEn() {
+  return <HomeView locale="en" />;
+}

--- a/src/app/en/posts/[slug]/page.tsx
+++ b/src/app/en/posts/[slug]/page.tsx
@@ -24,6 +24,7 @@ export function generateMetadata({ params }: Params): Metadata {
   const title = `${post.title} | ${SITE_NAME}`;
 
   return {
+    title,
     openGraph: {
       title,
       images: [AUTHOR_AVATAR],

--- a/src/app/en/posts/[slug]/page.tsx
+++ b/src/app/en/posts/[slug]/page.tsx
@@ -10,12 +10,12 @@ type Params = {
   };
 };
 
-export default function Post({ params }: Params) {
-  return <PostView slug={params.slug} locale="zh" />;
+export default function PostEn({ params }: Params) {
+  return <PostView slug={params.slug} locale="en" />;
 }
 
 export function generateMetadata({ params }: Params): Metadata {
-  const post = getPostBySlug(params.slug, 'zh');
+  const post = getPostBySlug(params.slug, 'en');
 
   if (!post) {
     return notFound();
@@ -32,7 +32,7 @@ export function generateMetadata({ params }: Params): Metadata {
 }
 
 export function generateStaticParams() {
-  const posts = getAllPosts('zh');
+  const posts = getAllPosts('en');
 
   return posts.map((post) => ({
     slug: post.slug,

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,13 +1,15 @@
 import Footer from '@/app/_components/footer';
+import { SITE_NAME, SITE_HOST, AUTHOR_AVATAR, GTM_ID } from '@/lib/constants';
 import {
-  SITE_NAME,
-  SITE_HOST,
-  SITE_DESCRIPTION,
-  AUTHOR_AVATAR,
-  GTM_ID,
-} from '@/lib/constants';
+  HTML_LANG,
+  OG_LOCALE,
+  canonicalize,
+  getMessages,
+  localePath,
+} from '@/lib/i18n';
 import type { Metadata } from 'next';
 import { Inter, JetBrains_Mono } from 'next/font/google';
+import { headers } from 'next/headers';
 import { Analytics } from '@vercel/analytics/react';
 import { SpeedInsights } from '@vercel/speed-insights/next';
 import { GoogleTagManager } from '@next/third-parties/google';
@@ -27,44 +29,65 @@ const mono = JetBrains_Mono({
   display: 'swap',
 });
 
-export const metadata: Metadata = {
-  metadataBase: new URL(SITE_HOST),
-  title: SITE_NAME,
-  description: SITE_DESCRIPTION,
-  openGraph: {
+function resolveLocaleFromHeaders() {
+  const path = headers().get('x-pathname') || '/';
+  return canonicalize(path);
+}
+
+export function generateMetadata(): Metadata {
+  const { locale, canonical } = resolveLocaleFromHeaders();
+  const t = getMessages(locale);
+  const oppositeLocale = locale === 'zh' ? 'en' : 'zh';
+
+  return {
+    metadataBase: new URL(SITE_HOST),
     title: SITE_NAME,
-    description: SITE_DESCRIPTION,
-    url: SITE_HOST,
-    siteName: SITE_NAME,
-    images: [AUTHOR_AVATAR],
-    locale: 'zh_CN',
-    type: 'website',
-  },
-  icons: {
-    icon: [
-      {
-        sizes: '32x32',
-        url: '/meta/favicon-32x32.png',
+    description: t.siteDescription,
+    openGraph: {
+      title: SITE_NAME,
+      description: t.siteDescription,
+      url: localePath(locale, canonical),
+      siteName: SITE_NAME,
+      images: [AUTHOR_AVATAR],
+      locale: OG_LOCALE[locale],
+      alternateLocale: [OG_LOCALE[oppositeLocale]],
+      type: 'website',
+    },
+    alternates: {
+      canonical: localePath(locale, canonical),
+      languages: {
+        'zh-Hans': localePath('zh', canonical),
+        en: localePath('en', canonical),
+        'x-default': localePath('zh', canonical),
       },
-      {
-        sizes: '16x16',
-        url: '/meta/favicon-16x16.png',
-      },
-    ],
-    shortcut: '/meta/favicon.ico',
-    apple: '/meta/apple-touch-icon.png',
-  },
-  manifest: '/meta/site.webmanifest',
-};
+    },
+    icons: {
+      icon: [
+        {
+          sizes: '32x32',
+          url: '/meta/favicon-32x32.png',
+        },
+        {
+          sizes: '16x16',
+          url: '/meta/favicon-16x16.png',
+        },
+      ],
+      shortcut: '/meta/favicon.ico',
+      apple: '/meta/apple-touch-icon.png',
+    },
+    manifest: '/meta/site.webmanifest',
+  };
+}
 
 export default function RootLayout({
   children,
 }: Readonly<{
   children: React.ReactNode;
 }>) {
+  const { locale } = resolveLocaleFromHeaders();
   return (
     <html
-      lang="en"
+      lang={HTML_LANG[locale]}
       className={`${sans.variable} ${mono.variable}`}
       suppressHydrationWarning
     >
@@ -72,7 +95,7 @@ export default function RootLayout({
         <Providers>
           <div className="flex min-h-screen flex-col">
             <div className="flex-1">{children}</div>
-            <Footer />
+            <Footer locale={locale} />
           </div>
         </Providers>
         <SpeedInsights />

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -1,22 +1,28 @@
 import Link from 'next/link';
+import { headers } from 'next/headers';
+import { canonicalize, getMessages, homePathFor } from '@/lib/i18n';
 import LegacyBlogHint from './_components/legacy-blog-hint';
 
 export default function NotFound() {
+  const path = headers().get('x-pathname') || '/';
+  const { locale } = canonicalize(path);
+  const t = getMessages(locale);
+
   return (
     <main className="flex min-h-screen flex-col items-center justify-center gap-6 px-6 text-center">
       <span className="font-mono text-xs uppercase tracking-widest text-brand">
-        Error 404
+        {t.notFound.tag}
       </span>
       <h1 className="text-display-sm font-semibold tracking-tightest text-ink dark:text-carbon-text">
-        Page not found
+        {t.notFound.title}
       </h1>
       <p className="max-w-md text-base text-ink-muted dark:text-carbon-muted">
-        The page you are looking for doesn&apos;t exist or has been moved.
+        {t.notFound.body}
       </p>
-      <Link href="/" className="btn-primary">
-        Go back home
+      <Link href={homePathFor(locale)} className="btn-primary">
+        {t.notFound.cta}
       </Link>
-      <LegacyBlogHint />
+      <LegacyBlogHint locale={locale} />
     </main>
   );
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,17 +1,5 @@
-import Container from '@/app/_components/container';
-import { Intro } from '@/app/_components/intro';
-import { Posts } from '@/app/_components/posts';
-import { getAllPosts } from '../lib/data';
+import { HomeView } from '@/app/_components/home-view';
 
 export default function Index() {
-  const allPosts = getAllPosts();
-
-  return (
-    <main>
-      <Container size="wide">
-        <Intro />
-        <Posts posts={allPosts} />
-      </Container>
-    </main>
-  );
+  return <HomeView locale="zh" />;
 }

--- a/src/app/posts/[slug]/page.tsx
+++ b/src/app/posts/[slug]/page.tsx
@@ -24,6 +24,7 @@ export function generateMetadata({ params }: Params): Metadata {
   const title = `${post.title} | ${SITE_NAME}`;
 
   return {
+    title,
     openGraph: {
       title,
       images: [AUTHOR_AVATAR],

--- a/src/interfaces/post.ts
+++ b/src/interfaces/post.ts
@@ -1,7 +1,13 @@
+import { Locale } from '@/lib/i18n';
+
 export type Post = {
   slug: string;
   title: string;
   date: string;
   preview: boolean;
   content: string;
+  locale: Locale;
+  requestedLocale: Locale;
+  isFallback: boolean;
+  availableLocales: Locale[];
 };

--- a/src/lib/actions.ts
+++ b/src/lib/actions.ts
@@ -6,6 +6,13 @@ import { revalidatePath } from 'next/cache';
 import { getSession } from '@auth0/nextjs-auth0';
 
 import { Reaction } from '@/interfaces/reaction';
+import { LOCALES, postPathFor } from '@/lib/i18n';
+
+function revalidatePostForAllLocales(slug: string) {
+  for (const locale of LOCALES) {
+    revalidatePath(postPathFor(locale, slug));
+  }
+}
 
 const CreateComment = z.object({
   slug: z.string(),
@@ -32,7 +39,7 @@ export async function createComment(slug: string, content: string) {
       picture = ${user.picture}
   `;
 
-  revalidatePath(`/posts/${slug}`);
+  revalidatePostForAllLocales(slug);
 }
 
 const DeleteComment = z.object({
@@ -52,7 +59,7 @@ export async function deleteComment(id: string, slug: string) {
     WHERE id = ${id} AND slug=${slug} AND author_sub=${user.sub}
   `;
 
-  revalidatePath(`/posts/${slug}`);
+  revalidatePostForAllLocales(slug);
 }
 
 const GetReactionsBySlug = z.object({
@@ -116,5 +123,5 @@ export async function addReaction(emoji: string, slug: string) {
     DO UPDATE SET count = reactions.count + 1
   `;
 
-  revalidatePath(`/posts/${slug}`);
+  revalidatePostForAllLocales(slug);
 }

--- a/src/lib/data.ts
+++ b/src/lib/data.ts
@@ -1,5 +1,6 @@
 import { Post } from '@/interfaces/post';
 import { Comment } from '@/interfaces/comment';
+import { DEFAULT_LOCALE, LOCALES, Locale } from '@/lib/i18n';
 import fs from 'fs';
 import matter from 'gray-matter';
 import { join } from 'path';
@@ -8,26 +9,72 @@ import { notFound } from 'next/navigation';
 
 const postsDirectory = join(process.cwd(), '_posts');
 
-export function getPostSlugs() {
-  return fs.readdirSync(postsDirectory);
+const LOCALE_SUFFIX_RE = /\.([a-z]{2})\.md$/i;
+
+function listMarkdownFiles(): string[] {
+  return fs.readdirSync(postsDirectory).filter((f) => f.endsWith('.md'));
 }
 
-export function getPostBySlug(slug: string) {
+export function getPostSlugs(): string[] {
+  const slugs = new Set<string>();
+  for (const file of listMarkdownFiles()) {
+    const match = file.match(LOCALE_SUFFIX_RE);
+    if (match) {
+      slugs.add(file.slice(0, -match[0].length));
+    } else {
+      slugs.add(file.slice(0, -3));
+    }
+  }
+  return Array.from(slugs);
+}
+
+function fileForLocale(slug: string, locale: Locale): string | null {
+  const filename =
+    locale === DEFAULT_LOCALE ? `${slug}.md` : `${slug}.${locale}.md`;
+  const fullPath = join(postsDirectory, filename);
+  return fs.existsSync(fullPath) ? fullPath : null;
+}
+
+function getAvailableLocales(slug: string): Locale[] {
+  return LOCALES.filter((l) => fileForLocale(slug, l) !== null);
+}
+
+export function getPostBySlug(
+  slug: string,
+  locale: Locale = DEFAULT_LOCALE,
+): Post {
   const realSlug = slug.replace(/\.md$/, '');
-  const fullPath = join(postsDirectory, `${realSlug}.md`);
-  if (!fs.existsSync(fullPath)) {
+
+  let actualLocale: Locale = locale;
+  let path = fileForLocale(realSlug, locale);
+
+  if (!path && locale !== DEFAULT_LOCALE) {
+    path = fileForLocale(realSlug, DEFAULT_LOCALE);
+    actualLocale = DEFAULT_LOCALE;
+  }
+
+  if (!path) {
     notFound();
   }
-  const fileContents = fs.readFileSync(fullPath, 'utf8');
+
+  const fileContents = fs.readFileSync(path, 'utf8');
   const { data, content } = matter(fileContents);
 
-  return { ...data, slug: realSlug, content } as Post;
+  return {
+    ...(data as Pick<Post, 'title' | 'date' | 'preview'>),
+    slug: realSlug,
+    content,
+    locale: actualLocale,
+    requestedLocale: locale,
+    isFallback: actualLocale !== locale,
+    availableLocales: getAvailableLocales(realSlug),
+  } as Post;
 }
 
-export function getAllPosts(): Post[] {
+export function getAllPosts(locale: Locale = DEFAULT_LOCALE): Post[] {
   const slugs = getPostSlugs();
   const posts = slugs
-    .map((slug) => getPostBySlug(slug))
+    .map((slug) => getPostBySlug(slug, locale))
     .filter((post) => process.env.PREVIEW_MODE || !post.preview)
     .sort((post1, post2) => (post1.date > post2.date ? -1 : 1));
   return posts;

--- a/src/lib/data.ts
+++ b/src/lib/data.ts
@@ -9,7 +9,7 @@ import { notFound } from 'next/navigation';
 
 const postsDirectory = join(process.cwd(), '_posts');
 
-const LOCALE_SUFFIX_RE = /\.([a-z]{2})\.md$/i;
+const LOCALE_SUFFIXES = LOCALES.map((locale) => `.${locale}.md`);
 
 function listMarkdownFiles(): string[] {
   return fs.readdirSync(postsDirectory).filter((f) => f.endsWith('.md'));
@@ -18,11 +18,13 @@ function listMarkdownFiles(): string[] {
 export function getPostSlugs(): string[] {
   const slugs = new Set<string>();
   for (const file of listMarkdownFiles()) {
-    const match = file.match(LOCALE_SUFFIX_RE);
-    if (match) {
-      slugs.add(file.slice(0, -match[0].length));
+    const localeSuffix = LOCALE_SUFFIXES.find((suffix) =>
+      file.endsWith(suffix),
+    );
+    if (localeSuffix) {
+      slugs.add(file.slice(0, -localeSuffix.length));
     } else {
-      slugs.add(file.slice(0, -3));
+      slugs.add(file.slice(0, -'.md'.length));
     }
   }
   return Array.from(slugs);

--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -1,0 +1,177 @@
+export const LOCALES = ['zh', 'en'] as const;
+export type Locale = (typeof LOCALES)[number];
+export const DEFAULT_LOCALE: Locale = 'zh';
+
+export const HTML_LANG: Record<Locale, string> = {
+  zh: 'zh-Hans',
+  en: 'en',
+};
+
+export const OG_LOCALE: Record<Locale, string> = {
+  zh: 'zh_CN',
+  en: 'en_US',
+};
+
+export const LOCALE_COOKIE = 'NEXT_LOCALE';
+
+export type Messages = {
+  siteDescription: string;
+  intro: { label: string; cliBadge: string };
+  posts: {
+    label: string;
+    title: string;
+    count: (n: number) => string;
+    fallbackTag: string;
+  };
+  post: {
+    label: string;
+    cliBadge: (slug: string) => string;
+    fallbackCallout: string;
+    fallbackCalloutLink: string;
+  };
+  reactions: { label: string; add: string };
+  comments: {
+    label: string;
+    title: string;
+    count: (n: number) => string;
+    empty: string;
+    placeholder: string;
+    submit: string;
+    loginCardTitle: string;
+    loginCardHint: string;
+    loginButton: string;
+    logout: string;
+    delete: string;
+  };
+  toggle: { theme: string; locale: string };
+  localeShort: Record<Locale, string>;
+  notFound: {
+    tag: string;
+    title: string;
+    body: string;
+    cta: string;
+    legacyHint: string;
+  };
+  footer: { builtWith: string };
+};
+
+export const messages: Record<Locale, Messages> = {
+  zh: {
+    siteDescription: '折腾、记录、思考。',
+    intro: { label: '— 个人博客', cliBadge: '~/blog $ ready' },
+    posts: {
+      label: '— 索引',
+      title: '全部文章',
+      count: (n) => `共 ${n} 篇`,
+      fallbackTag: 'ZH FALLBACK',
+    },
+    post: {
+      label: '— 文章',
+      cliBadge: (slug) => `cat ./posts/${slug}.md`,
+      fallbackCallout: '本文章暂无英文版本，正在显示中文原文。',
+      fallbackCalloutLink: '查看中文版',
+    },
+    reactions: { label: '— 表情', add: '添加表情' },
+    comments: {
+      label: '— 评论',
+      title: '讨论',
+      count: (n) => `${n} 条`,
+      empty: '暂无评论，欢迎留下你的想法。',
+      placeholder: '写下你的评论…',
+      submit: '发表',
+      loginCardTitle: '加入讨论',
+      loginCardHint: '登录后即可发表评论。',
+      loginButton: '登录',
+      logout: '登出',
+      delete: '删除',
+    },
+    toggle: { theme: '切换主题', locale: '切换语言' },
+    localeShort: { zh: '中', en: 'EN' },
+    notFound: {
+      tag: '错误 404',
+      title: '页面未找到',
+      body: '你访问的页面不存在或已被移动。',
+      cta: '回到首页',
+      legacyHint: '或许你是想访问旧的博客文章？可以看这里：',
+    },
+    footer: { builtWith: '使用 Next.js 构建' },
+  },
+  en: {
+    siteDescription: 'Tinkering, writing, and thinking out loud.',
+    intro: { label: '— Personal Blog', cliBadge: '~/blog $ ready' },
+    posts: {
+      label: '— Index',
+      title: 'All Posts',
+      count: (n) => `${n} entries`,
+      fallbackTag: 'ZH FALLBACK',
+    },
+    post: {
+      label: '— Article',
+      cliBadge: (slug) => `cat ./posts/${slug}.md`,
+      fallbackCallout:
+        "This article isn't available in English yet. Showing the original Chinese version.",
+      fallbackCalloutLink: 'View Chinese version',
+    },
+    reactions: { label: '— Reactions', add: 'Add reaction' },
+    comments: {
+      label: '— Comments',
+      title: 'Discussion',
+      count: (n) => `${n} ${n === 1 ? 'reply' : 'replies'}`,
+      empty: 'No comments yet. Be the first to leave a thought.',
+      placeholder: 'Add your comment...',
+      submit: 'Submit',
+      loginCardTitle: 'Join the discussion',
+      loginCardHint: 'Sign in to leave a comment.',
+      loginButton: 'Log in',
+      logout: 'Log out',
+      delete: 'Delete',
+    },
+    toggle: { theme: 'Toggle theme', locale: 'Toggle language' },
+    localeShort: { zh: '中', en: 'EN' },
+    notFound: {
+      tag: 'Error 404',
+      title: 'Page not found',
+      body: "The page you are looking for doesn't exist or has been moved.",
+      cta: 'Go back home',
+      legacyHint: 'Looking for an older post? Try the legacy site:',
+    },
+    footer: { builtWith: 'Built with Next.js' },
+  },
+};
+
+export function getMessages(locale: Locale): Messages {
+  return messages[locale];
+}
+
+export function isLocale(value: string | undefined | null): value is Locale {
+  return value === 'zh' || value === 'en';
+}
+
+export function canonicalize(pathname: string): {
+  locale: Locale;
+  canonical: string;
+} {
+  if (pathname === '/en') {
+    return { locale: 'en', canonical: '/' };
+  }
+  if (pathname.startsWith('/en/')) {
+    return { locale: 'en', canonical: pathname.slice(3) };
+  }
+  return { locale: 'zh', canonical: pathname };
+}
+
+export function localePath(locale: Locale, canonical: string): string {
+  const path = canonical || '/';
+  if (locale === 'en') {
+    return path === '/' ? '/en' : `/en${path}`;
+  }
+  return path;
+}
+
+export function homePathFor(locale: Locale): string {
+  return localePath(locale, '/');
+}
+
+export function postPathFor(locale: Locale, slug: string): string {
+  return localePath(locale, `/posts/${slug}`);
+}


### PR DESCRIPTION
…e switcher and Accept-Language detection.

- Locale-aware data layer with per-slug locale resolution and zh fallback.
- /en route subtree mirrors zh routes; shared HomeView/PostView render either locale.
- LocaleSwitcher (mono ZH/EN button) placed alongside ThemeSwitcher.
- Middleware redirects unprefixed paths based on NEXT_LOCALE cookie or Accept-Language header.
- Per-locale metadata, html lang, hreflang alternates, and OpenGraph locales.
- ZH FALLBACK badge in en list, fallback callout on en post pages without translation.
- Comments and Reactions revalidate both locale paths after writes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added English language support for all pages and content alongside Chinese
  * Introduced locale switcher in header for instant language toggling
  * Automatic locale detection from browser preferences with cookie persistence
  * Locale-prefixed URLs for improved accessibility and routing
  * Localized UI text throughout the application

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/southerncross/next-blog/pull/50)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->