### PR TITLE
fix: :lipstick: Fix inline code colors in light and dark themes.

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -41,6 +41,32 @@
     max-width: 100%;
     height: auto;
   }
+
+  .prose :where(span[data-rehype-pretty-code-figure]) > code {
+    background-color: rgb(243 244 246) !important;
+    color: rgb(17 17 17) !important;
+    padding: 0.15em 0.4em;
+    border-radius: 4px;
+    font-size: 0.875em;
+    font-weight: 500;
+    border: 1px solid rgb(229 231 235);
+  }
+
+  .dark .prose :where(span[data-rehype-pretty-code-figure]) > code {
+    background-color: rgb(31 31 31) !important;
+    color: rgb(229 231 235) !important;
+    border-color: rgb(38 38 38);
+  }
+
+  .prose :where(span[data-rehype-pretty-code-figure]) > code span {
+    color: inherit !important;
+    background-color: transparent !important;
+  }
+
+  .prose :where(span[data-rehype-pretty-code-figure]) > code::before,
+  .prose :where(span[data-rehype-pretty-code-figure]) > code::after {
+    content: none !important;
+  }
 }
 
 @layer components {


### PR DESCRIPTION
## 问题

`rehype-pretty-code` 配合 `theme: 'github-dark-dimmed'` + `defaultLang: 'ansi'` 会给 inline code 注入硬编码的 `background-color:#22272e;color:#adbac7`，导致日间模式下 inline code 也是深灰底，看起来非常突兀。

## 修复

在 `src/app/globals.css` 中针对 `span[data-rehype-pretty-code-figure] > code`（即 inline 形式）增加覆盖：

- 日间：浅灰底 `rgb(243 244 246)` + 细边框
- 夜间：`rgb(31 31 31)` 底 + 略亮文字，沿用 `carbon-*` 调色板
- 重置内部 shiki span 的 `color` / `background` 让它继承外层
- 去掉 typography 默认的反引号 `::before`/`::after`

块代码（`pre > code`）不受影响。

## 校验

`pnpm lint` / `pnpm typecheck` / `pnpm format:check` / `pnpm build` 全部通过。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated styling for syntax-highlighted code blocks with improved visual presentation. Changes include adjustments to background colors, text colors, padding, border radius, font sizing and weight, and border styling. Enhanced appearance now includes optimized dark mode support for better readability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/southerncross/next-blog/pull/57?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->