### PR TITLE
style: :lipstick: Restyle block code as terminal-aesthetic dark card.

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -67,6 +67,51 @@
   .prose :where(span[data-rehype-pretty-code-figure]) > code::after {
     content: none !important;
   }
+
+  .prose figure[data-rehype-pretty-code-figure] {
+    margin: 1.6em 0;
+    border-radius: 8px;
+    border: 1px solid #1f1f1f;
+    background-color: #0a0a0a;
+    overflow: hidden;
+  }
+
+  .prose figure[data-rehype-pretty-code-figure] > pre {
+    background-color: transparent !important;
+    color: #e5e7eb !important;
+    margin: 0 !important;
+    padding: 1em 1.25em !important;
+    border-radius: 0 !important;
+    font-size: 0.875em;
+    line-height: 1.65;
+    overflow-x: auto;
+  }
+
+  .prose figure[data-rehype-pretty-code-figure] > pre > code {
+    background-color: transparent !important;
+    padding: 0 !important;
+    font-weight: 400;
+    font-family: var(--font-geist-mono), ui-monospace, SFMono-Regular, Menlo,
+      Consolas, monospace;
+  }
+
+  .prose figure[data-rehype-pretty-code-figure] > pre > code::before,
+  .prose figure[data-rehype-pretty-code-figure] > pre > code::after {
+    content: none !important;
+  }
+
+  .prose figure[data-rehype-pretty-code-figure] > pre::-webkit-scrollbar {
+    height: 8px;
+  }
+
+  .prose figure[data-rehype-pretty-code-figure] > pre::-webkit-scrollbar-thumb {
+    background-color: rgba(255, 255, 255, 0.12);
+    border-radius: 4px;
+  }
+
+  .prose figure[data-rehype-pretty-code-figure] > pre::-webkit-scrollbar-track {
+    background-color: transparent;
+  }
 }
 
 @layer components {


### PR DESCRIPTION
## 背景

`rehype-pretty-code` 默认输出的 `github-dark-dimmed` 块代码（蓝灰底 `#22272e`、无边框、默认 padding）和站点 Factory.ai-inspired 设计语言不太一致。

## 改动

针对 `figure[data-rehype-pretty-code-figure]` 重写块代码外观：

- 外框：`#0A0A0A` 底 + `#1F1F1F` hairline 边框 + 8px 圆角，对齐 `DESIGN.md` 的 `dark_background` ("terminal sections / inversion blocks") 与 `radius.buttons` 8px、border-first 原则。
- `<pre>`: 透明背景（覆盖 rehype-pretty-code 内联的 `#22272e`），文字 `#E5E7EB`，padding 收紧到 `1em 1.25em`，line-height 1.65。
- `<code>`: 显式 Geist Mono，去掉 typography 默认反引号 `::before`/`::after`。
- 8px 高的低对比度 webkit 滚动条样式，避免长代码行横向滚动时滚动条突兀。

## 设计决策：日夜同款

日间也保留深色块。`DESIGN.md` 写明：

- `dark_background.usage: 'Hero sections, terminal sections, inversion blocks'`
- `layout.principles: 'Alternating dark/light sections'`
- `imagery.rules: 'Terminal/code snippets highly encouraged'`、`'Black/orange technical aesthetic'`

块代码即「terminal section / inversion block」，日间不切浅色主题。如果未来需要日夜双主题，应通过 rehype-pretty-code 的 `theme: { light, dark }` 模式重新生成 HTML，CSS 层不强行覆盖 shiki token 颜色。

## 校验

`pnpm lint` / `pnpm typecheck` / `pnpm format:check` / `pnpm build` 全部通过。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enhanced visual styling and formatting for code blocks in documentation, including improved layout, typography, and padding
  * Customized scrollbar appearance for code snippet views for better visual consistency

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/southerncross/next-blog/pull/58?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->