### PR TITLE
revert: :rewind: Remove ISR revalidation from RSS feeds.

### DIFF
--- a/src/app/en/feed.xml/route.ts
+++ b/src/app/en/feed.xml/route.ts
@@ -1,7 +1,6 @@
 import { generateRssFeed } from '@/lib/rss';
 
 export const dynamic = 'force-static';
-export const revalidate = 3600;
 
 export async function GET() {
   const body = generateRssFeed('en');

--- a/src/app/feed.xml/route.ts
+++ b/src/app/feed.xml/route.ts
@@ -1,7 +1,6 @@
 import { generateRssFeed } from '@/lib/rss';
 
 export const dynamic = 'force-static';
-export const revalidate = 3600;
 
 export async function GET() {
   const body = generateRssFeed('zh');


### PR DESCRIPTION
Feed content is fully derived from committed markdown and only changes on redeploy, so hourly revalidation adds no benefit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated RSS feed caching configuration for improved build-time rendering strategy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->