### PR TITLE
fix: :bug: Fix post table rendering whitespace

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -113,16 +113,20 @@
     background-color: transparent;
   }
 
-  .prose :where(table) {
-    display: block;
-    width: 100%;
+  .prose :where(.table-wrapper) {
     overflow-x: auto;
-    border-collapse: collapse;
     margin: 1.8em 0;
-    font-size: 0.92em;
     border: 1px solid rgb(var(--border));
     border-radius: 8px;
     background-color: rgb(var(--surface));
+  }
+
+  .prose :where(.table-wrapper table) {
+    display: table;
+    width: 100%;
+    border-collapse: collapse;
+    margin: 0 !important;
+    font-size: 0.92em;
   }
 
   .prose :where(table thead) {
@@ -158,16 +162,16 @@
     background-color: rgba(243, 111, 54, 0.04);
   }
 
-  .prose :where(table)::-webkit-scrollbar {
+  .prose :where(.table-wrapper)::-webkit-scrollbar {
     height: 8px;
   }
 
-  .prose :where(table)::-webkit-scrollbar-thumb {
+  .prose :where(.table-wrapper)::-webkit-scrollbar-thumb {
     background-color: rgba(0, 0, 0, 0.12);
     border-radius: 4px;
   }
 
-  .dark .prose :where(table)::-webkit-scrollbar-thumb {
+  .dark .prose :where(.table-wrapper)::-webkit-scrollbar-thumb {
     background-color: rgba(255, 255, 255, 0.12);
   }
 }

--- a/src/lib/markdownToHtml.ts
+++ b/src/lib/markdownToHtml.ts
@@ -7,12 +7,14 @@ import rehypePrettyCode from 'rehype-pretty-code';
 import rehypeSlug from 'rehype-slug';
 import rehypeAutolinkHeadings from 'rehype-autolink-headings';
 import rehypeInlineSvg from './rehypeInlineSvg';
+import rehypeWrapTable from './rehypeWrapTable';
 
 export default async function markdownToHtml(markdown: string) {
   const result = await remark()
     .use(remarkGfm)
     .use(remarkRehype)
     .use(rehypeInlineSvg)
+    .use(rehypeWrapTable)
     .use(rehypePrettyCode, {
       theme: 'github-dark-dimmed',
       defaultLang: 'ansi',

--- a/src/lib/rehypeWrapTable.ts
+++ b/src/lib/rehypeWrapTable.ts
@@ -1,0 +1,22 @@
+import { visit } from 'unist-util-visit';
+import type { Element, Root } from 'hast';
+
+export default function rehypeWrapTable() {
+  return function transformer(tree: Root) {
+    visit(tree, 'element', (node, index, parent) => {
+      if (!parent || index == null || node.tagName !== 'table') {
+        return;
+      }
+
+      const wrapper: Element = {
+        type: 'element',
+        tagName: 'div',
+        properties: { className: ['table-wrapper'] },
+        children: [node],
+      };
+
+      parent.children.splice(index, 1, wrapper);
+      return index + 1;
+    });
+  };
+}


### PR DESCRIPTION
## What

Fixes two table rendering issues in markdown posts:

1. **Right-side gap** — tables used `display: block; width: 100%`, which made the block full-width while the inner table content shrank to fit, leaving empty space on the right for narrow tables.
2. **Top/bottom whitespace** — the default prose table `margin: 2em` became visible inside the new scroll wrapper.

## How

- Added `src/lib/rehypeWrapTable.ts`, a small rehype plugin that wraps each `<table>` in a `<div class="table-wrapper">`, registered in the markdown pipeline.
- Moved the box/border/radius and horizontal-scroll styling onto `.table-wrapper`, and set the table to `display: table; width: 100%` so it fills the container and still scrolls horizontally when content overflows.
- Reset the table margin with `margin: 0 !important` to beat the typography plugin's `components`-layer defaults (matching the existing pretty-code override pattern).

## Validation

- `pnpm lint`, `pnpm typecheck`, `pnpm format:check`, `pnpm build` all pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Restructured table rendering to wrap tables in a container element, enabling better control over styling, layout, and scrollbar behavior in markdown content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->