### PR TITLE
fix: :bug: Sort post reactions by click count

### DIFF
--- a/src/lib/actions.ts
+++ b/src/lib/actions.ts
@@ -77,30 +77,32 @@ export async function getReactionsBySlug(slug: string) {
     }>`
     SELECT emoji, count, slug
     FROM reactions
-    WHERE slug = ${realSlug} ORDER BY created_at DESC
+    WHERE slug = ${realSlug} ORDER BY created_at ASC
   `;
 
-    const reactions = data.rows.map((row) => {
+    const savedReactions = data.rows.map((row) => {
       return {
         emoji: row.emoji,
-        count: row.count,
+        count: Number(row.count),
         slug: row.slug,
       } as Reaction;
     });
 
     const defaultEmojis = ['👍', '❤️', '🤔', '🤡'];
-    const savedEmojiSet = new Set(reactions.map((x) => x.emoji));
+    const savedEmojiMap = new Map(savedReactions.map((x) => [x.emoji, x]));
 
-    defaultEmojis
-      .reverse()
-      .filter((x) => !savedEmojiSet.has(x))
-      .forEach((emoji) => {
-        reactions.unshift({
-          emoji,
-          count: 0,
-          slug: realSlug,
-        });
-      });
+    // Build a stable base order (default emojis first, then custom ones by
+    // creation time) so equal-count reactions keep a predictable position.
+    const reactions: Reaction[] = [
+      ...defaultEmojis.map(
+        (emoji) =>
+          savedEmojiMap.get(emoji) ?? { emoji, count: 0, slug: realSlug },
+      ),
+      ...savedReactions.filter((x) => !defaultEmojis.includes(x.emoji)),
+    ];
+
+    // Stable sort by click count, highest first.
+    reactions.sort((a, b) => b.count - a.count);
 
     return reactions;
   } catch (e) {


### PR DESCRIPTION
## Problem

In the reaction area at the bottom of each post, clicking an emoji caused it to jump to the end of the list.

### Root cause

In `getReactionsBySlug` the display order was assembled as:
1. DB reactions (emojis that had been clicked) ordered by `created_at DESC`.
2. Default emojis that had **not** been clicked were `unshift`-ed to the front.

So as soon as a default emoji was clicked it left the front group and joined the saved group behind all the still-unclicked defaults, pushing it to the tail.

## Fix

Reorder reactions by **click count, highest first**, with a stable base order (default emojis in canonical order, then custom emojis by creation time) so equal-count reactions keep a predictable position.

## Validation

- `pnpm lint` ✅
- `pnpm typecheck` ✅
- `pnpm format:check` ✅
- `pnpm build` ✅

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reaction ordering and sorting logic to display reactions by popularity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->