### PR TITLE
fix: :lipstick: Wrap long links to prevent mobile overflow.

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -43,8 +43,7 @@
   }
 
   .prose :where(a, p, li) {
-    overflow-wrap: break-word;
-    word-break: break-word;
+    overflow-wrap: anywhere;
   }
 
   .prose :where(span[data-rehype-pretty-code-figure]) > code {

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -42,6 +42,11 @@
     height: auto;
   }
 
+  .prose :where(a, p, li) {
+    overflow-wrap: break-word;
+    word-break: break-word;
+  }
+
   .prose :where(span[data-rehype-pretty-code-figure]) > code {
     background-color: rgb(243 244 246) !important;
     color: rgb(17 17 17) !important;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Improved text wrapping for links, paragraphs, and list items by ensuring long prose breaks cleanly, preventing overflow and improving readability across screen sizes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->