### PR TITLE
feat: :card_index_dividers: Add robots.txt and sitemap.xml routes.

### DIFF
--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -1,0 +1,18 @@
+import type { MetadataRoute } from 'next';
+import { SITE_HOST } from '@/lib/constants';
+
+export const dynamic = 'force-static';
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: [
+      {
+        userAgent: '*',
+        allow: '/',
+        disallow: ['/api/'],
+      },
+    ],
+    sitemap: `${SITE_HOST}/sitemap.xml`,
+    host: SITE_HOST,
+  };
+}

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,0 +1,34 @@
+import type { MetadataRoute } from 'next';
+import { SITE_HOST } from '@/lib/constants';
+import { getAllPosts } from '@/lib/data';
+import { LOCALES, homePathFor, postPathFor } from '@/lib/i18n';
+
+export const dynamic = 'force-static';
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  const postEntries: MetadataRoute.Sitemap = [];
+  let latest = new Date(0);
+
+  for (const locale of LOCALES) {
+    for (const post of getAllPosts(locale)) {
+      if (post.locale !== locale) continue;
+      const lastModified = new Date(post.date);
+      if (lastModified > latest) latest = lastModified;
+      postEntries.push({
+        url: `${SITE_HOST}${postPathFor(locale, post.slug)}`,
+        lastModified,
+        changeFrequency: 'monthly',
+        priority: 0.8,
+      });
+    }
+  }
+
+  const homeEntries: MetadataRoute.Sitemap = LOCALES.map((locale) => ({
+    url: `${SITE_HOST}${homePathFor(locale)}`,
+    lastModified: latest,
+    changeFrequency: 'weekly',
+    priority: 1,
+  }));
+
+  return [...homeEntries, ...postEntries];
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a robots.txt configuration that permits search engine crawling while excluding API routes.
  * Added sitemap generation for localized home pages and posts.
  * Included site host and sitemap references in crawler metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->